### PR TITLE
Correctly encode links before their display

### DIFF
--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -17,12 +17,19 @@
 
       // whitelist "safe" URL and URI schemes, and warn for others
       safe_regexp = /^(ftps?|https?):\/\/|(about|geo|mailto):/i;
+      var link = document.createElement('a');
+      link.href = urlhash;
+      link.appendChild(document.createTextNode(urlhash));
+      h3 = document.createElement('h3');
+      h3.appendChild(link);
+
       if (!safe_regexp.test(urlhash)) {
         the_content.innerHTML = '<h4>Unknown URI scheme &ndash; possible XSS attempt?</h4>' +
-          '<h4>Proceed with caution:</h4><h3><a href="'+urlhash+'">'+urlhash+'</a></h3>';
-        return;
+          '<h4>Proceed with caution:</h4>';
+        the_content.append(h3);
       } else {
-        the_content.innerHTML = '<h4>Referer protection &ndash; Click to visit this external link:</h4><h3><a href="'+urlhash+'">'+urlhash+'</a></h3>';
+        the_content.innerHTML = '<h4>Referer protection &ndash; Click to visit this external link:</h4>';
+        the_content.append(h3);
       }
     } else {
       the_content.innerHTML = '<h4>Nothing to see here. Move along.</h4>';


### PR DESCRIPTION
This PR aims to fix #6, which describes a DOM-based _Cross-Site Scripting_. Since navigators are not exposing any usable API to protect against this kind of attacks, I had to rely on `createElement` and `createTextNode`. 

Reproduction steps:
- Start an instance with ep_hide_referrer loaded;
- Access http://0.0.0.0:9001/redirect#http://%3Cimg%20src=#%20onerror=alert(document.domain)%3E;
- If no alert shows up and the link is correctly displayed (`http://<img src=# onerror=alert(document.domain)>`), it's fixed. 

FTR, it won't prevent _Cross-site Scripting_ attacks with links starting with `javascript:` and `data:`, they should probably be completely blocked (but that's for another PR :-)).