### PR TITLE
fixes to cases where the referrer was is leaked

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5,7 +5,7 @@ exports.postAceInit = function(hook, context){
     return false;
   });
 
-  $('#chattext > p').on('click', "a", function (e){
+  $('#chattext').on('click', "a", function (e){
     window.open('../redirect#'+escape(e.currentTarget.href));
     e.preventDefault();
     return false;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5,11 +5,28 @@ exports.postAceInit = function(hook, context){
     return false;
   });
 
+  $('iframe[name="ace_outer"]').contents().find('iframe').contents().find("#innerdocbody").on('contextmenu', "a", function (e){
+    $(this).attr('href','../redirect#'+escape(e.currentTarget.href));
+  });
+
   $('#chattext').on('click', "a", function (e){
-    window.open('../redirect#'+escape(e.currentTarget.href));
+    if ( $(this).hasClass('no-referrer') ) {
+        window.open(e.currentTarget.href);
+    } else {
+        window.open('../redirect#'+escape(e.currentTarget.href));
+    }
     e.preventDefault();
     return false;
   });
+
+  $('#chattext').on('contextmenu', "a", function (e){
+    if ( !$(this).hasClass('no-referrer') ) {
+       $(this).attr('rel','noreferrer');
+       $(this).addClass('no-referrer');
+       $(this).attr('href','../redirect#'+escape(e.currentTarget.href));
+    }
+  });
+
 }
 
 exports.postTimesliderInit = function(hook, context){
@@ -18,4 +35,9 @@ exports.postTimesliderInit = function(hook, context){
     e.preventDefault();
     return false;
   });
+
+  $('#padcontent').on('contextmenu', 'a', function (e){
+    $(this).attr('rel','noreferrer');
+  });
+
 }

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -25,8 +25,8 @@
 
       if (!safe_regexp.test(urlhash)) {
         the_content.innerHTML = '<h4>Unknown URI scheme &ndash; possible XSS attempt?</h4>' +
-          '<h4>Proceed with caution:</h4>';
-        the_content.append(h3);
+          '<p><strong>This appears to be a malicious link.<br> If you are sure it\'s safe and you know what you\'re doing,<br> please copy and paste the following into your browser\'s address bar:</strong></p>';
+        the_content.append(link.href);
       } else {
         the_content.innerHTML = '<h4>Referer protection &ndash; Click to visit this external link:</h4>';
         the_content.append(h3);


### PR DESCRIPTION
The first one is in the chat messages, where it seems the function that redirects the link was failing to applied. The second one is triggered by the "right click" menu in firefox esr/tor browser at least (https://github.com/ether/ep_hide_referrer/issues/18).

As the chat links work differently than the pad ones, I'm adding a class to figure out if it was modified already or not. There can (and probably are) better ways to solve this situation, so I'm open to try them if you point me to the right direction.

Thanks for you work with this plugin!